### PR TITLE
FEAT: provider for category and type cube, FIX: animation splash

### DIFF
--- a/lib/config/matrix_cube/matrix.dart
+++ b/lib/config/matrix_cube/matrix.dart
@@ -1,37 +1,30 @@
-enum Type{
-  cube2x2,
-  cube3x3,
-  cube4x4,
-  cube5x5,
-  cube6x6,
-  cube7x7
-}
+import '../puzzle_options/puzzle_options_enum.dart';
 
 ///Given a Type enum(Type.cube2x2, Type.cube3x3...) return an int from the respect type(2,3...)
-Map<Type, int> nCubeType = {
-  Type.cube2x2:2,
-  Type.cube3x3:3,
-  Type.cube4x4:4,
-  Type.cube5x5:5,
-  Type.cube6x6:6,
-  Type.cube7x7:7
+Map<CubeType, int> nCubeType = {
+  CubeType.cube2x2:2,
+  CubeType.cube3x3:3,
+  CubeType.cube4x4:4,
+  CubeType.cube5x5:5,
+  CubeType.cube6x6:6,
+  CubeType.cube7x7:7
 };
 
-Map<int,Type> intToType = {
-  2:Type.cube2x2,
-  3:Type.cube3x3,
-  4:Type.cube4x4,
-  5:Type.cube5x5,
-  6:Type.cube6x6,
-  7:Type.cube7x7
+Map<int,CubeType> intToType = {
+  2:CubeType.cube2x2,
+  3:CubeType.cube3x3,
+  4:CubeType.cube4x4,
+  5:CubeType.cube5x5,
+  6:CubeType.cube6x6,
+  7:CubeType.cube7x7
 };
 
 class Matrix {
   List<List<int>> _matrix = List.generate(1, (i) => []);
-  Type? type;
+  CubeType? type;
   int? length;
 
-  Matrix(Type typeCube, int element){
+  Matrix(CubeType typeCube, int element){
     type= typeCube;
     _matrix = List.generate(nCubeType[type]!, (index) => []);
     for(var i=0; i<nCubeType[type]!; i++){

--- a/lib/config/puzzle_options/puzzle_options_enum.dart
+++ b/lib/config/puzzle_options/puzzle_options_enum.dart
@@ -1,0 +1,18 @@
+//cube type
+enum CubeType {
+  cube2x2,
+  cube3x3,
+  cube4x4,
+  cube5x5,
+  cube6x6,
+  cube7x7
+}
+
+final Map<CubeType, String> cubeTypeToString = {
+  CubeType.cube2x2: '2x2 Cube',
+  CubeType.cube3x3: '3x3 Cube',
+  CubeType.cube4x4: '4x4 Cube',
+  CubeType.cube5x5: '5x5 Cube',
+  CubeType.cube6x6: '6x6 Cube',
+  CubeType.cube7x7: '7x7 Cube',
+};

--- a/lib/presentation/features/appbar/app_bar_feature.dart
+++ b/lib/presentation/features/appbar/app_bar_feature.dart
@@ -16,16 +16,16 @@ class AppBarHome extends StatefulWidget implements PreferredSizeWidget {
   // final Type typeCube;
 
   const AppBarHome({
+    super.key,
     required this.onPressedDrawer,
     required this.onPressedTittle,
     required this.themeColor,
     required this.textColor,
     required this.scaffoldKey,
     required this.isTimerRunnin,
-    super.key,
+    required this.tittle,
+    required this.subtittle,
     this.widthDevice = 0,
-    this.tittle = 'Cubo 3x3',
-    this.subtittle = 'normal',
     this.actualPageIndex,
     //required this.typeCube
   });

--- a/lib/presentation/providers/puzzle_options_provider.dart
+++ b/lib/presentation/providers/puzzle_options_provider.dart
@@ -1,0 +1,44 @@
+import 'package:cube_timer_2/config/puzzle_options/puzzle_options_enum.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class PuzzleOptions {
+  final CubeType puzzleOption;
+  final String puzzleCategory;
+
+  PuzzleOptions({
+    this.puzzleOption = CubeType.cube3x3,
+    this.puzzleCategory = "normal",
+  });
+
+  PuzzleOptions copyWith({
+    CubeType? puzzleOption,
+    String? puzzleCategory,
+  }) {
+    return PuzzleOptions(
+      puzzleOption: puzzleOption ?? this.puzzleOption,
+      puzzleCategory: puzzleCategory ?? this.puzzleCategory,
+    );
+  }
+}
+
+class PuzzleOptionsProvider extends StateNotifier<PuzzleOptions> {
+  PuzzleOptionsProvider(): super(PuzzleOptions(
+    puzzleOption: CubeType.cube3x3,
+    puzzleCategory: "normal",
+  ));
+  
+
+  void setPuzzleOption(int puzzleOption) {
+    CubeType selectedPuzzleOption = CubeType.values[puzzleOption];
+    state = state.copyWith(puzzleOption: selectedPuzzleOption);
+  }
+
+  void setPuzzleCategory(String puzzleCategory) {
+    state = state.copyWith(puzzleCategory: puzzleCategory);
+  }
+}
+
+final puzzleOptionsProvider = StateNotifierProvider<PuzzleOptionsProvider, PuzzleOptions>((ref) {
+  return PuzzleOptionsProvider();
+});
+

--- a/lib/presentation/screens/home/home_screen.dart
+++ b/lib/presentation/screens/home/home_screen.dart
@@ -1,7 +1,9 @@
 // import 'package:cube_timer_v2/config/config.dart';
 import 'package:cube_timer_2/config/config.dart';
+import 'package:cube_timer_2/config/puzzle_options/puzzle_options_enum.dart';
 import 'package:cube_timer_2/presentation/features/features.dart';
 import 'package:cube_timer_2/presentation/providers/providers.dart';
+import 'package:cube_timer_2/presentation/providers/puzzle_options_provider.dart';
 import 'package:cube_timer_2/presentation/widgets/puzzle_widgets/puzzle_selection.dart';
 
 import 'package:flutter/material.dart';
@@ -17,6 +19,7 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    //gemeral config theme
     final bool isDarkMode = ref.watch(themeNotifierProvider).isDarkmode;
     final int actualThemeIndex =
         ref.watch(themeNotifierProvider).actualThemeIndex;
@@ -31,8 +34,15 @@ class HomeScreen extends ConsumerWidget {
     );
 
     //body changes
-    final int selectedOption = ref.watch(menuOptionsNotifierProvider).actualOption;
+    final int selectedOption =
+        ref.watch(menuOptionsNotifierProvider).actualOption;
     final bool isTimerRunning = ref.watch(cronometerRunnerProvider).isRunning;
+
+    //appBar category changes
+    final CubeType actualOption =
+        ref.watch(puzzleOptionsProvider).puzzleOption;
+    final String actualCategory =
+        ref.watch(puzzleOptionsProvider).puzzleCategory;
 
     return SafeArea(
       bottom: true,
@@ -44,6 +54,8 @@ class HomeScreen extends ConsumerWidget {
           appBar: AppBarHome(
             isTimerRunnin: isTimerRunning,
             actualPageIndex: indexPage,
+            tittle: cubeTypeToString[actualOption]!,
+            subtittle: actualCategory,
             textColor: (actualTextColorIndex == 0)
                 ? (isDarkMode)
                     ? Colors.black
@@ -52,74 +64,80 @@ class HomeScreen extends ConsumerWidget {
             themeColor: appColorTheme[actualThemeIndex].appBarColor,
             scaffoldKey: scaffoldKey,
             onPressedDrawer: () => scaffoldKey.currentState?.openDrawer(),
-            
+
             //tittle change according to the selected option
             // tittle: appMenuScreensItems[selectedOption].title,
             // subtittle: 'xd',
-            onPressedTittle: () => 
-              showDialog(
+            onPressedTittle: () => showDialog(
                 context: context,
                 builder: (context) => CustomAlertDialog(
-                  tittle: 'Select a puzzle',
-                  fontTittleSize: 20.0,
-                  context: context,
-                  insetPadding: const EdgeInsets.symmetric(horizontal: 30),
-                  contentPadding: const EdgeInsets.only(
-                      right: 0, left: 0, top: 0, bottom: 0),
-                  content: const <Widget>[
-                    PuzzleSelection(),
-                  ],
-                )),
+                      tittle: 'Select a puzzle',
+                      fontTittleSize: 20.0,
+                      context: context,
+                      insetPadding: const EdgeInsets.symmetric(horizontal: 30),
+                      contentPadding: const EdgeInsets.only(
+                          right: 0, left: 0, top: 0, bottom: 0),
+                      content: const <Widget>[
+                        PuzzleSelection(),
+                      ],
+                    )),
           ),
-          body: _getBodyContent(pageController, appColorTheme[actualThemeIndex].patternColor ,selectedOption, actualThemeIndex, ref, context),
-          bottomNavigationBar: selectedOption == 0 || selectedOption == 2 || selectedOption == 3
-            ? CustomBottomNavigationBar(
-                isTimerRunning: isTimerRunning,
-                pageController: pageController,
-                backgroundColor: appColorTheme[actualThemeIndex].bnBarColor,
-                activeIconColor: actualTextColorIndex == 0
-                    ? appColorTheme[actualThemeIndex].isDarkmode
-                        ? Colors.black
-                        : Colors.white
-                    : appTextTheme[actualTextColorIndex].colorText,
-                inactiveIconColor: appColorTheme[actualThemeIndex].isDarkmode
-                    ? Colors.black54
-                    : Colors.white54,
-                onTap: (index) {
-                  pageController.animateToPage(
-                    index,
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeInOut,
-                  );
-                  ref.read(pageIndexProviderInt.notifier).setPageIndex(index);
-                },
-              )
-            : null,
+          body: _getBodyContent(
+              pageController,
+              appColorTheme[actualThemeIndex].patternColor,
+              selectedOption,
+              actualThemeIndex,
+              ref,
+              context),
+          bottomNavigationBar: selectedOption == 0 ||
+                  selectedOption == 2 ||
+                  selectedOption == 3
+              ? CustomBottomNavigationBar(
+                  isTimerRunning: isTimerRunning,
+                  pageController: pageController,
+                  backgroundColor: appColorTheme[actualThemeIndex].bnBarColor,
+                  activeIconColor: actualTextColorIndex == 0
+                      ? appColorTheme[actualThemeIndex].isDarkmode
+                          ? Colors.black
+                          : Colors.white
+                      : appTextTheme[actualTextColorIndex].colorText,
+                  inactiveIconColor: appColorTheme[actualThemeIndex].isDarkmode
+                      ? Colors.black54
+                      : Colors.white54,
+                  onTap: (index) {
+                    pageController.animateToPage(
+                      index,
+                      duration: const Duration(milliseconds: 300),
+                      curve: Curves.easeInOut,
+                    );
+                    ref.read(pageIndexProviderInt.notifier).setPageIndex(index);
+                  },
+                )
+              : null,
           drawer: const DrawerHome()),
     );
   }
 
-  Widget _getBodyContent( PageController pageController, ColorPair patternColor,
-      int currentOption, int actualThemeIndex, WidgetRef ref, context)  {
+  Widget _getBodyContent(PageController pageController, ColorPair patternColor,
+      int currentOption, int actualThemeIndex, WidgetRef ref, context) {
     switch (currentOption) {
       case 0:
         return MainBody(
-          optionBody: 0, //main body in constructor
-          patternColor: appColorTheme[actualThemeIndex].patternColor,
-          pageController: pageController
-        );
+            optionBody: 0, //main body in constructor
+            patternColor: appColorTheme[actualThemeIndex].patternColor,
+            pageController: pageController);
       case 2:
         return MainBody(
-          optionBody: 1, //oll training body in constructor
-          patternColor: const ColorPair(primaryColor: Colors.black, secondaryColor: Colors.white),
-          pageController: pageController
-        );
+            optionBody: 1, //oll training body in constructor
+            patternColor: const ColorPair(
+                primaryColor: Colors.black, secondaryColor: Colors.white),
+            pageController: pageController);
       case 3:
         return MainBody(
-          optionBody: 2, //pll training body in constructor
-          patternColor: const ColorPair(primaryColor: Colors.red, secondaryColor: Colors.green),
-          pageController: pageController
-        );
+            optionBody: 2, //pll training body in constructor
+            patternColor: const ColorPair(
+                primaryColor: Colors.red, secondaryColor: Colors.green),
+            pageController: pageController);
       case 5:
         return const Center(child: Text("Contenido de Opción 2"));
       case 6:

--- a/lib/presentation/widgets/puzzle_widgets/button_splash.dart
+++ b/lib/presentation/widgets/puzzle_widgets/button_splash.dart
@@ -1,29 +1,64 @@
 import 'package:cube_timer_2/config/config.dart';
+import 'package:cube_timer_2/presentation/providers/puzzle_options_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-/// **IOS**: animation IOS scale entire button with animation container.
+/// **IOS**: animation IOS scale entire button with animation container (still pending).
 ///
 /// **ANDROID**: animation Android only splash on long press like original material design for twisty timer.
-class ButtonSplash extends StatefulWidget {
+class ButtonSplash extends ConsumerStatefulWidget {
   final EdgeInsetsGeometry padding;
   final int addingIndex;
   final double screen;
-  const ButtonSplash(
-      {super.key,
-      required this.addingIndex,
-      required this.screen,
-      required this.padding});
+  // final void Function()? onTap;
+  const ButtonSplash({
+    super.key,
+    required this.addingIndex,
+    required this.screen,
+    required this.padding,
+  });
 
   @override
-  State<ButtonSplash> createState() => _ButtonSplashState();
+  ConsumerState<ConsumerStatefulWidget> createState() => _ButtonSplashState();
 }
 
-class _ButtonSplashState extends State<ButtonSplash> {
+class _ButtonSplashState extends ConsumerState<ButtonSplash>
+    with SingleTickerProviderStateMixin {
   OverlayEntry? _overlayEntry;
+  late AnimationController _animationController;
+  late Animation<double> _scaleAnimation;
+  bool _isTouchDisabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      reverseDuration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+    _scaleAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    ));
+  }
+
+  @override
+  dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
 
   void _showOverlay(BuildContext context, Offset position, Size size) {
+    _removeOverlay();
     _overlayEntry = _createOverlayEntry(context, position, size);
     Overlay.of(context).insert(_overlayEntry!);
+    _animationController.forward();
   }
 
   OverlayEntry _createOverlayEntry(
@@ -34,12 +69,15 @@ class _ButtonSplashState extends State<ButtonSplash> {
         top: position.dy - 37.5, // Adjust to control the splash position
         width: size.width + 75, // Adjust to control the splash size
         height: size.height + 75, // Adjust to control the splash size
-        child: Material(
-          color: Colors.transparent,
-          child: Container(
-            decoration: BoxDecoration(
-              color: Colors.white.withAlpha(70),
-              shape: BoxShape.circle,
+        child: ScaleTransition(
+          scale: _scaleAnimation,
+          child: Material(
+            color: Colors.transparent,
+            child: Container(
+              decoration: BoxDecoration(
+                color: Colors.black.withAlpha(30),
+                shape: BoxShape.circle,
+              ),
             ),
           ),
         ),
@@ -48,15 +86,22 @@ class _ButtonSplashState extends State<ButtonSplash> {
   }
 
   void _removeOverlay() {
-    _overlayEntry?.remove();
-    _overlayEntry = null;
+    if (_overlayEntry != null) {
+      _animationController.reverse().then((_) {
+        _overlayEntry?.remove();
+        _overlayEntry = null;
+        setState(() {
+          _isTouchDisabled = false;
+        });
+      });
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return Container(
       margin: widget.padding,
-      color: Colors.blue,
+      // color: Colors.blue,
       width:
           (widget.screen < 431) ? MediaQuery.of(context).size.width - 40 : 400,
       height: (MediaQuery.of(context).size.height > 500)
@@ -72,11 +117,16 @@ class _ButtonSplashState extends State<ButtonSplash> {
               transform: Matrix4.identity()..scale(1.0, 1.0),
               child: GestureDetector(
                 onTapDown: (details) {
-                  RenderBox renderBox =
-                      key.currentContext!.findRenderObject() as RenderBox;
-                  Offset position = renderBox.localToGlobal(Offset.zero);
-                  Size size = renderBox.size;
-                  _showOverlay(context, position, size);
+                  if (!_isTouchDisabled) {
+                    setState(() {
+                      _isTouchDisabled = true;
+                    });
+                    RenderBox renderBox =
+                        key.currentContext!.findRenderObject() as RenderBox;
+                    Offset position = renderBox.localToGlobal(Offset.zero);
+                    Size size = renderBox.size;
+                    _showOverlay(context, position, size);
+                  }
                 },
                 onTapUp: (details) {
                   _removeOverlay();
@@ -85,11 +135,20 @@ class _ButtonSplashState extends State<ButtonSplash> {
                   _removeOverlay();
                 },
                 onLongPressStart: (details) {
-                  RenderBox renderBox =
-                      key.currentContext!.findRenderObject() as RenderBox;
-                  Offset position = renderBox.localToGlobal(Offset.zero);
-                  Size size = renderBox.size;
-                  _showOverlay(context, position, size);
+                  if (!_isTouchDisabled) {
+                    setState(() {
+                      _isTouchDisabled = true;
+                    });
+                    RenderBox renderBox =
+                        key.currentContext!.findRenderObject() as RenderBox;
+                    Offset position = renderBox.localToGlobal(Offset.zero);
+                    Size size = renderBox.size;
+                    _showOverlay(context, position, size);
+                  }
+                  ref.read(puzzleOptionsProvider.notifier).setPuzzleOption(
+                        widget.addingIndex + index,
+                      );
+                  context.pop();
                 },
                 onLongPressEnd: (details) {
                   _removeOverlay();
@@ -105,11 +164,6 @@ class _ButtonSplashState extends State<ButtonSplash> {
                       // height: (MediaQuery.of(context).size.width) / 8,
                       height: 50,
                       decoration: BoxDecoration(
-                        // color: index == 0
-                        //     ? Color.fromRGBO(231, 10, 234, 0.4)
-                        //     : index == 1
-                        //         ? Color.fromRGBO(10, 250, 234, 0.3)
-                        //         : Color.fromRGBO(10, 10, 250, 0.3),
                         borderRadius: BorderRadius.circular(10),
                       ),
                       child: Material(
@@ -117,16 +171,20 @@ class _ButtonSplashState extends State<ButtonSplash> {
                         child: InkWell(
                           highlightColor: Colors.transparent,
                           borderRadius: BorderRadius.circular(10),
-                          onTap: () {},
-                          splashColor:
-                              Colors.transparent, // Disable default splash
+                          onTap: () {
+                            ref.read(puzzleOptionsProvider.notifier).setPuzzleOption(
+                              widget.addingIndex + index,
+                            );
+                            context.pop();
+                          },
+                          splashColor: Colors.transparent,
                           child: Column(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: <Widget>[
-                              iconList[index],
+                              iconList[widget.addingIndex + index],
                               SizedBox(height: 5),
                               Text(
-                                '${index + 2}x${index + 2} Cube',
+                                '${widget.addingIndex + index + 2}x${widget.addingIndex + index + 2} Cube',
                                 style: TextStyle(fontSize: 12),
                               ),
                             ],
@@ -144,3 +202,196 @@ class _ButtonSplashState extends State<ButtonSplash> {
     );
   }
 }
+
+/// **IOS**: animation IOS scale entire button with animation container (still pending).
+///
+/// **ANDROID**: animation Android only splash on long press like original material design for twisty timer.
+// class ButtonSplash extends StatefulWidget {
+//   final EdgeInsetsGeometry padding;
+//   final int addingIndex;
+//   final double screen;
+//   // final void Function()? onTap;
+//   const ButtonSplash(
+//       {super.key,
+//       required this.addingIndex,
+//       required this.screen,
+//       required this.padding,
+//     });
+
+//   @override
+//   State<ButtonSplash> createState() => _ButtonSplashState();
+// }
+
+// class _ButtonSplashState extends State<ButtonSplash>
+//     with SingleTickerProviderStateMixin {
+//   OverlayEntry? _overlayEntry;
+//   late AnimationController _animationController;
+//   late Animation<double> _scaleAnimation;
+//   bool _isTouchDisabled = false;
+
+//   @override
+//   void initState() {
+//     super.initState();
+
+//     _animationController = AnimationController(
+//       duration: const Duration(milliseconds: 200),
+//       reverseDuration: const Duration(milliseconds: 200),
+//       vsync: this,
+//     );
+//     _scaleAnimation = Tween<double>(
+//       begin: 0.0,
+//       end: 1.0,
+//     ).animate(CurvedAnimation(
+//       parent: _animationController,
+//       curve: Curves.easeInOut,
+//     ));
+//   }
+
+//   @override
+//   dispose() {
+//     _animationController.dispose();
+//     super.dispose();
+//   }
+
+//   void _showOverlay(BuildContext context, Offset position, Size size) {
+//     _removeOverlay();
+//     _overlayEntry = _createOverlayEntry(context, position, size);
+//     Overlay.of(context).insert(_overlayEntry!);
+//     _animationController.forward();
+//   }
+
+//   OverlayEntry _createOverlayEntry(
+//       BuildContext context, Offset position, Size size) {
+//     return OverlayEntry(
+//       builder: (context) => Positioned(
+//         left: position.dx - 37.5, // Adjust to control the splash position
+//         top: position.dy - 37.5, // Adjust to control the splash position
+//         width: size.width + 75, // Adjust to control the splash size
+//         height: size.height + 75, // Adjust to control the splash size
+//         child: ScaleTransition(
+//           scale: _scaleAnimation,
+//           child: Material(
+//             color: Colors.transparent,
+//             child: Container(
+//               decoration: BoxDecoration(
+//                 color: Colors.black.withAlpha(30),
+//                 shape: BoxShape.circle,
+//               ),
+//             ),
+//           ),
+//         ),
+//       ),
+//     );
+//   }
+
+//   void _removeOverlay() {
+//     if (_overlayEntry != null) {
+//       _animationController.reverse().then((_) {
+//         _overlayEntry?.remove();
+//         _overlayEntry = null;
+//         setState(() {
+//           _isTouchDisabled = false;
+//         });
+//       });
+//     }
+//   }
+
+//   @override
+//   Widget build(BuildContext context) {
+//     return Container(
+//       margin: widget.padding,
+//       // color: Colors.blue,
+//       width:
+//           (widget.screen < 431) ? MediaQuery.of(context).size.width - 40 : 400,
+//       height: (MediaQuery.of(context).size.height > 500)
+//           ? (MediaQuery.of(context).size.width - 80) / 4
+//           : 120,
+//       child: ListView.builder(
+//         scrollDirection: Axis.horizontal,
+//         itemCount: 3,
+//         itemBuilder: (context, index) {
+//           GlobalKey key = GlobalKey();
+//           return Center(
+//             child: Transform(
+//               transform: Matrix4.identity()..scale(1.0, 1.0),
+//               child: GestureDetector(
+//                 onTapDown: (details) {
+//                   if (!_isTouchDisabled) {
+//                     setState(() {
+//                       _isTouchDisabled = true;
+//                     });
+//                     RenderBox renderBox =
+//                         key.currentContext!.findRenderObject() as RenderBox;
+//                     Offset position = renderBox.localToGlobal(Offset.zero);
+//                     Size size = renderBox.size;
+//                     _showOverlay(context, position, size);
+//                   }
+//                 },
+//                 onTapUp: (details) {
+//                   _removeOverlay();
+//                 },
+//                 onTapCancel: () {
+//                   _removeOverlay();
+//                 },
+//                 onLongPressStart: (details) {
+//                   if (!_isTouchDisabled) {
+//                     setState(() {
+//                       _isTouchDisabled = true;
+//                     });
+//                     RenderBox renderBox =
+//                         key.currentContext!.findRenderObject() as RenderBox;
+//                     Offset position = renderBox.localToGlobal(Offset.zero);
+//                     Size size = renderBox.size;
+//                     _showOverlay(context, position, size);
+//                   }
+//                 },
+//                 onLongPressEnd: (details) {
+//                   _removeOverlay();
+//                 },
+//                 onTap: () => {
+//                   debugPrint('Button tapped!'),
+//                 },
+//                 child: Stack(
+//                   children: [
+//                     Container(
+//                       //container for every children
+//                       key: key,
+//                       width: (MediaQuery.of(context).size.width < 500)
+//                           ? (MediaQuery.of(context).size.width) / 3.5
+//                           : 133,
+//                       // height: (MediaQuery.of(context).size.width) / 8,
+//                       height: 50,
+//                       decoration: BoxDecoration(
+//                         borderRadius: BorderRadius.circular(10),
+//                       ),
+//                       child: Material(
+//                         color: Colors.transparent,
+//                         child: InkWell(
+//                           highlightColor: Colors.transparent,
+//                           borderRadius: BorderRadius.circular(10),
+//                           onTap: () {},
+//                           splashColor: Colors.transparent,
+//                           child: Column(
+//                             mainAxisAlignment: MainAxisAlignment.center,
+//                             children: <Widget>[
+//                               iconList[widget.addingIndex + index],
+//                               SizedBox(height: 5),
+//                               Text(
+//                                 '${widget.addingIndex + index + 2}x${widget.addingIndex + index + 2} Cube',
+//                                 style: TextStyle(fontSize: 12),
+//                               ),
+//                             ],
+//                           ),
+//                         ),
+//                       ),
+//                     ),
+//                   ],
+//                 ),
+//               ),
+//             ),
+//           );
+//         },
+//       ),
+//     );
+//   }
+// }

--- a/lib/presentation/widgets/puzzle_widgets/puzzle_selection.dart
+++ b/lib/presentation/widgets/puzzle_widgets/puzzle_selection.dart
@@ -1,256 +1,30 @@
 import 'package:cube_timer_2/presentation/widgets/puzzle_widgets/button_splash.dart';
 import 'package:flutter/material.dart';
-// import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// class PuzzleSelection extends ConsumerStatefulWidget {
-//   const PuzzleSelection({super.key});
-
-//   @override
-//   ConsumerState<ConsumerStatefulWidget> createState() => _PuzzleSelectionState();
-// }
-
-// class _PuzzleSelectionState extends ConsumerState<PuzzleSelection> {
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return Container();
-//   }
-// }
-
-class PuzzleSelection extends StatefulWidget {
+class PuzzleSelection extends StatelessWidget {
   const PuzzleSelection({super.key});
 
   @override
-  State<PuzzleSelection> createState() => _PuzzleSelectionState();
-}
-
-class _PuzzleSelectionState extends State<PuzzleSelection> {
-  @override
   Widget build(BuildContext context) {
     final screen = MediaQuery.of(context).size.width;
+    
 
     return Column(
       key: const Key('puzzle_selection'),
       children: <Widget>[
         const SizedBox(height: 13),
-          ButtonSplash(
-            addingIndex: 0, 
-            screen: screen,
-            padding: const EdgeInsets.symmetric(horizontal: 0),
-          ),
-          ButtonSplash(
-            addingIndex: 3,
-            screen: screen,
-            padding: EdgeInsets.all(0),
-          ),
+        ButtonSplash(
+          addingIndex: 0,
+          screen: screen,
+          padding: const EdgeInsets.symmetric(horizontal: 0),
+        ),
+        ButtonSplash(
+          addingIndex: 3,
+          screen: screen,
+          padding: EdgeInsets.all(0),
+        ),
         // _buttonScale(3),
-
       ],
     );
   }
-
-  // Widget _buttonScale(int index) {
-  //     return Center(
-  //         child: Transform(
-  //           transform: Matrix4.identity()..scale(1.0, 1.0),
-  //           child: Stack(
-  //               children: [
-  //                 Container(
-  //                         width: (MediaQuery.of(context).size.width < 500)
-  //                             ? (MediaQuery.of(context).size.width) / 3.5
-  //                             : 120,
-  //                         height: (MediaQuery.of(context).size.width) / 3.5,
-  //                         decoration: BoxDecoration(
-  //                           color: index == 0
-  //                               ? Color.fromRGBO(231, 10, 234, 0.4)
-  //                               : index == 1
-  //                                   ? Color.fromRGBO(10, 250, 234, 0.3)
-  //                                   : Color.fromRGBO(10, 10, 250, 0.3),
-  //                           borderRadius: BorderRadius.circular(10),
-  //                         ),
-  //                         child: ElevatedButton(
-  //                           style: ElevatedButton.styleFrom(
-  //                             backgroundColor: Colors.transparent,
-  //                             shadowColor: Colors.transparent,
-  //                           ),
-  //                           onPressed: () {},
-  //                           child: Column(
-  //                             mainAxisAlignment: MainAxisAlignment.center,
-  //                             children: <Widget>[
-  //                               iconList[index],
-  //                               SizedBox(height: 5),
-  //                               Text(
-  //                                 '${index + 2}x${index + 2} Cube',
-  //                                 style: TextStyle(fontSize: 12),
-  //                               ),
-  //                             ],
-  //                           ),
-  //                         ),
-  //                       ),
-  //                 ]
-  //                 )));
-  //               }
-
 }
-
-// class PuzzleSelection extends StatelessWidget {
-//   const PuzzleSelection({super.key});
-
-//   @override
-//   Widget build(BuildContext context) {
-
-//   final screen = MediaQuery.of(context).size.width;
-//     return Column(
-//       key: const Key('puzzle_selection'),
-//       children: <Widget>[
-//         const SizedBox(height: 10),
-//         _columnPuzzleOptions(0, screen, context),
-//         _columnPuzzleOptions(3, screen, context),
-//       ],
-//     );
-//   }
-
-//   OverlayEntry? _overlayEntry;
-
-//   OverlayEntry _createOverlayEntry(BuildContext context, Offset position, Size size) {
-//     return OverlayEntry(
-//       builder: (context) => Positioned(
-//         left: position.dx,
-//         top: position.dy,
-//         width: size.width,
-//         height: size.height,
-//         child: Material(
-//           color: Colors.transparent,
-//           child: Container(
-//             decoration: BoxDecoration(
-//               color: Colors.white..withAlpha(76),
-//               borderRadius: BorderRadius.circular(10),
-//             ),
-//           ),
-//         ),
-//       ),
-//     );
-//   }
-
-
-//   void _showOverlay(BuildContext context, Offset position, Size size) {
-//     _overlayEntry = _createOverlayEntry(context, position, size);
-//     Overlay.of(context)?.insert(_overlayEntry!);
-//   }
-
-//   void _removeOverlay() {
-//     _overlayEntry?.remove();
-//     _overlayEntry = null;
-//   }
-
-//   Container _columnPuzzleOptions(int addingIndex, double screen, BuildContext context) {
-//     return Container(
-//         color: Colors.blue,
-//         width: (screen < 431)
-//             ? MediaQuery.of(context).size.width - 40
-//             : 400,
-//         height: (MediaQuery.of(context).size.height > 500) 
-//           ? (MediaQuery.of(context).size.width - 80) / 3
-//           : 120,
-//         child: ListView.builder(
-//           scrollDirection: Axis.horizontal,
-//           itemCount: 3,
-//             itemBuilder: (context, index) {
-//               Center(
-//             child: Transform(
-//               transform: Matrix4.identity()..scale(1.0, 1.0),
-//               child: GestureDetector(
-//                 onLongPressStart: (details) {
-//                   RenderBox renderBox = context.findRenderObject() as RenderBox;
-//                   Offset position = renderBox.localToGlobal(Offset.zero);
-//                   Size size = renderBox.size;
-//                   _showOverlay(context, position, size);
-//                 },
-//                 onLongPressEnd: (details) {
-//                   _removeOverlay();
-//                 },
-//                 child: Stack(
-//                   children: [
-//                     Container(
-//                       width: (MediaQuery.of(context).size.width < 500)
-//                           ? (MediaQuery.of(context).size.width) / 3.5
-//                           : 120,
-//                       height: (MediaQuery.of(context).size.width) / 3.5,
-//                       decoration: BoxDecoration(
-//                         color: index == 0
-//                             ? Color.fromRGBO(231, 10, 234, 0.4)
-//                             : index == 1
-//                                 ? Color.fromRGBO(10, 250, 234, 0.3)
-//                                 : Color.fromRGBO(10, 10, 250, 0.3),
-//                         borderRadius: BorderRadius.circular(10),
-//                       ),
-//                       child: Material(
-//                         color: Colors.transparent,
-//                         child: InkWell(
-//                           borderRadius: BorderRadius.circular(10),
-//                           onTap: () {},
-//                           splashColor: Colors.white.withOpacity(0.3),
-//                           child: Column(
-//                             mainAxisAlignment: MainAxisAlignment.center,
-//                             children: <Widget>[
-//                               iconList[index],
-//                               SizedBox(height: 5),
-//                               Text(
-//                                 '${index + 2}x${index + 2} Cube',
-//                                 style: TextStyle(fontSize: 12),
-//                               ),
-//                             ],
-//                           ),
-//                         ),
-//                       ),
-//                     ),
-//                   ],
-//                 ),
-//               ),
-//             ),
-//           );
-//           //   return Center(
-//           // child: Transform(
-
-//           //   transform: Matrix4.identity()..scale(1.0, 1.0),
-//           //   child: Stack(
-//           //       children: [
-//           //         Container(
-//           //                 width: (MediaQuery.of(context).size.width < 500)
-//           //                     ? (MediaQuery.of(context).size.width) / 3.5
-//           //                     : 120,
-//           //                 height: (MediaQuery.of(context).size.width) / 3.5,
-//           //                 decoration: BoxDecoration(
-//           //                   color: index == 0
-//           //                       ? Color.fromRGBO(231, 10, 234, 0.4)
-//           //                       : index == 1
-//           //                           ? Color.fromRGBO(10, 250, 234, 0.3)
-//           //                           : Color.fromRGBO(10, 10, 250, 0.3),
-//           //                   borderRadius: BorderRadius.circular(10),
-//           //                 ),
-//           //                 child: ElevatedButton(
-//           //                   style: ElevatedButton.styleFrom(
-//           //                     backgroundColor: Colors.transparent,
-//           //                     shadowColor: Colors.transparent,
-//           //                   ),
-//           //                   onPressed: () {},
-//           //                   child: Column(
-//           //                     mainAxisAlignment: MainAxisAlignment.center,
-//           //                     children: <Widget>[
-//           //                       iconList[index],
-//           //                       SizedBox(height: 5),
-//           //                       Text(
-//           //                         '${index + 2}x${index + 2} Cube',
-//           //                         style: TextStyle(fontSize: 12),
-//           //                       ),
-//           //                     ],
-//           //                   ),
-//           //                 ),
-//           //               ),
-//           //         ]
-//           //         )));
-//                 }
-//               ),
-//             );
-//           }
-//   }


### PR DESCRIPTION
Fix animation splash causing splash in every row of inkwells when longpressing one the buttons alredy.
create a provider that can change category and type for cubes. :D 

TODO: still missing the conection with database to save the times and stuff, but its someting im still working on it. Big problem now happens on .svg to show cube already scrambleded, need to create and structure that generate those .svg files. also its still peding the times history section (NEED FUCKING HEEEELP!!!)